### PR TITLE
add correct types for ring buffer node

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "circuit-breaker",
+  "name": "circuit-breaker-ts",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "circuit-breaker",
+      "name": "circuit-breaker-ts",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -4,7 +4,8 @@
   "description": "Automatically detect and respond to failures in dependencies of a system",
   "main": "circuitbreaker.ts",
   "scripts": {
-    "test": "ts-node ./tests/circuitbreaker.test.ts"
+    "test": "ts-node ./tests/circuitbreaker.test.ts",
+    "type": "tsc"
   },
   "author": "",
   "license": "ISC",

--- a/typescript/src/circuitbreaker.ts
+++ b/typescript/src/circuitbreaker.ts
@@ -1,6 +1,6 @@
 class BufferNode<T> {
-  value: any;
-  next: BufferNode<any> | null;
+  value: T;
+  next: BufferNode<T> | null;
 
   constructor(value: T) {
     this.value = value;
@@ -8,10 +8,10 @@ class BufferNode<T> {
   }
 }
 
-class RingBuffer {
+class RingBuffer<T> {
   #length: number;
-  #cursor: BufferNode<any>;
-  #firstNode: BufferNode<any>;
+  #cursor: BufferNode<T>;
+  #firstNode: BufferNode<T>;
 
   constructor(elements: number) {
     this.#length = elements;
@@ -19,7 +19,7 @@ class RingBuffer {
     this.#firstNode;
 
     for (let i = 0; i < elements; i++) {
-      let node = new BufferNode(null);
+      let node = new BufferNode<T>(null);
 
       if (i === 0) {
         this.#firstNode = node;
@@ -143,6 +143,12 @@ interface Config {
 export type CircuitState = "closed" | "open" | "half_open";
 export type EventResult = "success" | "failure";
 
+type NodeValue = {
+  expires: number,
+  errorCount: number,
+  totalCount: number,
+}
+
 export class CircuitBreaker {
   static State = {
     Closed: "closed" as CircuitState,
@@ -155,7 +161,7 @@ export class CircuitBreaker {
     Failure: "failure" as EventResult,
   } as const;
 
-  #ring: RingBuffer;
+  #ring: RingBuffer<NodeValue>;
   #state: CircuitState;
   #date: DateDependency;
 
@@ -202,10 +208,10 @@ export class CircuitBreaker {
       typeof evalWindow.spans !== "number" ||
       evalWindow.spans <= 0
     ) {
-      this.#ring = new RingBuffer(6);
+      this.#ring = new RingBuffer<NodeValue>(6);
       this.#spanDuration = 120000;
     } else {
-      this.#ring = new RingBuffer(evalWindow.spans + 1);
+      this.#ring = new RingBuffer<NodeValue>(evalWindow.spans + 1);
       this.#spanDuration = (evalWindow.minutes / evalWindow.spans) * 60000;
     }
 

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
The Generic types for the `RingBuffer` and `BufferNode` classes are now setup correctly. The correct value for the generic is now used when the `RingBuffer` is instantiated.