### PR TITLE
refactor ring buffer to use fixed size array instead of linked list

### DIFF
--- a/go/circuitbreaker_test.go
+++ b/go/circuitbreaker_test.go
@@ -102,8 +102,8 @@ func TestCircuitBreaker(t *testing.T) {
 	rate = cb.GetErrorRate()
 	state = cb.GetState()
 
-	assert(t, 0.0, rate)
 	assert(t, circuitbreaker.Open, state)
+	assert(t, 0.0, rate)
 
 	// Third - wait 1 minute for the circuit to move to HalfOpen
 	FastForward(61*time.Second, mockTime)

--- a/go/ringbuffer.go
+++ b/go/ringbuffer.go
@@ -1,0 +1,78 @@
+package circuitbreaker
+
+import (
+	"math"
+	"time"
+)
+
+type Node struct {
+	Expires      time.Time
+	FailureCount int
+	SuccessCount int
+}
+
+func (n *Node) Reset(expires time.Time) {
+	n.Expires = expires
+	n.FailureCount = 0
+	n.SuccessCount = 0
+}
+
+func (n *Node) Clear() {
+	n.Expires = time.Time{}
+	n.FailureCount = 0
+	n.SuccessCount = 0
+}
+
+type RingBuffer struct {
+	cursor int
+	nodes  []Node
+}
+
+func NewRingBuffer(size int) *RingBuffer {
+	return &RingBuffer{
+		cursor: 0,
+		nodes:  make([]Node, size),
+	}
+}
+
+func (r *RingBuffer) Next() {
+	if r.cursor == len(r.nodes)-1 {
+		r.cursor = 0
+	} else {
+		r.cursor += 1
+	}
+}
+
+func (r *RingBuffer) Len() int {
+	return len(r.nodes)
+}
+
+func (r *RingBuffer) Cursor() *Node {
+	return &r.nodes[r.cursor]
+}
+
+func (r *RingBuffer) GetErrorRate(minEvalSize int) float64 {
+	failures := 0
+	total := 0
+
+	for i, c := range r.nodes {
+		if i == r.cursor {
+			continue
+		}
+		failures += c.FailureCount
+		total += +c.FailureCount + c.SuccessCount
+	}
+
+	if total < minEvalSize || total == 0 {
+		return 0
+	}
+
+	errorRate := (float64(failures) / float64(total)) * 100
+	return math.Round(errorRate*100) / 100
+}
+
+func (r *RingBuffer) ClearBuffer() {
+	for i := range r.nodes {
+		r.nodes[i].Clear()
+	}
+}


### PR DESCRIPTION
The Go implementation used the standard library `container/ring` package to create the buffer used to store the circuit breaker traffic state, such as success and failure count and expiration. As the circuit breaker design evolved it was decided that the number of nodes in the buffer is fixed when the circuit breaker is initialised. This means that the benefits that a linked list has over managing the ring buffer as an array(adding and removing nodes can be done in O(1) as linked list) was no longer relevant. We could achieve our design in a simpler way by having a fixed size array and maintaining the index of the cursor to know which node is active.

Benchmark tests don't indicate that using a fixed size array approach causes any regressions