### PR TITLE
only recalculate error rate when buffer cursor moves

### DIFF
--- a/go/circuitbreaker_test.go
+++ b/go/circuitbreaker_test.go
@@ -103,7 +103,7 @@ func TestCircuitBreaker(t *testing.T) {
 	state = cb.GetState()
 
 	assert(t, circuitbreaker.Open, state)
-	assert(t, 0.0, rate)
+	assert(t, rate, 0.0)
 
 	// Third - wait 1 minute for the circuit to move to HalfOpen
 	FastForward(61*time.Second, mockTime)


### PR DESCRIPTION
The existing implementation would calculate the error rate every time a new even was recorded. The error rate only changes when the active buffer node changes.

This PR updates to only calculate the error rate when the active buffer node changes. Benchmarks indicate that improves average speed of Record method from ~105 ns/op to ~90 ns/op